### PR TITLE
feature: firebase auth emulator support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Required
+FIREBASE_API_KEY=<firebase-api-key>
+
+# Optional
+FIREBASE_EMULATOR_HOST=<firebase-emulator-host>
+FIREBASE_EMULATOR_PORT=<firebase-emulator-port>

--- a/example/main.dart
+++ b/example/main.dart
@@ -13,10 +13,12 @@ Future main(List<String> arguments) async {
   final emulatorHost = arguments.asMap().containsKey(1) ? arguments[1] : null;
   final emulatorPort =
       arguments.asMap().containsKey(2) ? int.tryParse(arguments[2]) : null;
+  EmulatorConfig? emulator;
   if (emulatorHost != null && emulatorPort != null) {
     print(
       'Connecting to firebase auth emulator at http://$emulatorHost:$emulatorPort',
     );
+    emulator = EmulatorConfig(host: emulatorHost, port: emulatorPort);
   }
 
   try {
@@ -25,8 +27,7 @@ Future main(List<String> arguments) async {
       client,
       arguments[0],
       locale: 'en-US',
-      emulatorHost: emulatorHost,
-      emulatorPort: emulatorPort,
+      emulator: emulator,
     );
 
     // login, set autoRefresh to true to automatically refresh the idToken in

--- a/example/main.dart
+++ b/example/main.dart
@@ -6,9 +6,28 @@ import 'package:http/http.dart';
 
 Future main(List<String> arguments) async {
   final client = Client();
+
+  // optional:
+  // parse the 2nd and 3rd args to get the emulatorHost and emulatorPort
+  // make sure to run firebase emulators:start before doing this
+  final emulatorHost = arguments.asMap().containsKey(1) ? arguments[1] : null;
+  final emulatorPort =
+      arguments.asMap().containsKey(2) ? int.tryParse(arguments[2]) : null;
+  if (emulatorHost != null && emulatorPort != null) {
+    print(
+      'Connecting to firebase auth emulator at http://$emulatorHost:$emulatorPort',
+    );
+  }
+
   try {
     // create a firebase auth instance
-    final fbAuth = FirebaseAuth(client, arguments[0], 'en-US');
+    final fbAuth = FirebaseAuth(
+      client,
+      arguments[0],
+      locale: 'en-US',
+      emulatorHost: emulatorHost,
+      emulatorPort: emulatorPort,
+    );
 
     // login, set autoRefresh to true to automatically refresh the idToken in
     // the background

--- a/lib/firebase_auth_rest.dart
+++ b/lib/firebase_auth_rest.dart
@@ -1,3 +1,4 @@
+export 'src/emulator_config.dart';
 export 'src/firebase_account.dart';
 export 'src/firebase_auth.dart';
 export 'src/models/auth_exception.dart';

--- a/lib/src/emulator_config.dart
+++ b/lib/src/emulator_config.dart
@@ -1,0 +1,18 @@
+/// Config with options for connecting the the Firebase auth emulator
+class EmulatorConfig {
+  /// The URI host. Example: "127.0.0.1" or "localhost"
+  final String host;
+
+  /// The URI port. Example 4050
+  final int port;
+
+  /// The URI protocol. Default is "https".
+  final String protocol;
+
+  /// Create a new EmulatorConfig instance
+  const EmulatorConfig({
+    required this.host,
+    required this.port,
+    this.protocol = 'http',
+  });
+}

--- a/lib/src/firebase_account.dart
+++ b/lib/src/firebase_account.dart
@@ -65,10 +65,17 @@ class FirebaseAccount {
     Client client,
     String apiKey,
     SignInResponse signInResponse, {
+    String? emulatorHost,
+    int? emulatorPort,
     bool autoRefresh = true,
     String? locale,
   }) : this.apiCreate(
-          RestApi(client, apiKey),
+          RestApi(
+            client,
+            apiKey,
+            emulatorHost: emulatorHost,
+            emulatorPort: emulatorPort,
+          ),
           signInResponse,
           autoRefresh: autoRefresh,
           locale: locale,
@@ -100,11 +107,18 @@ class FirebaseAccount {
     Client client,
     String apiKey,
     String refreshToken, {
+    String? emulatorHost,
+    int? emulatorPort,
     bool autoRefresh = true,
     String? locale,
   }) =>
       apiRestore(
-        RestApi(client, apiKey),
+        RestApi(
+          client,
+          apiKey,
+          emulatorHost: emulatorHost,
+          emulatorPort: emulatorPort,
+        ),
         refreshToken,
         autoRefresh: autoRefresh,
         locale: locale,

--- a/lib/src/firebase_account.dart
+++ b/lib/src/firebase_account.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:http/http.dart';
 
+import 'emulator_config.dart';
 import 'firebase_auth.dart';
 import 'models/auth_exception.dart';
 import 'models/delete_request.dart';
@@ -65,16 +66,14 @@ class FirebaseAccount {
     Client client,
     String apiKey,
     SignInResponse signInResponse, {
-    String? emulatorHost,
-    int? emulatorPort,
-    bool autoRefresh = true,
     String? locale,
+    bool autoRefresh = true,
+    EmulatorConfig? emulator,
   }) : this.apiCreate(
           RestApi(
             client,
             apiKey,
-            emulatorHost: emulatorHost,
-            emulatorPort: emulatorPort,
+            emulator: emulator,
           ),
           signInResponse,
           autoRefresh: autoRefresh,
@@ -107,17 +106,15 @@ class FirebaseAccount {
     Client client,
     String apiKey,
     String refreshToken, {
-    String? emulatorHost,
-    int? emulatorPort,
     bool autoRefresh = true,
     String? locale,
+    EmulatorConfig? emulator,
   }) =>
       apiRestore(
         RestApi(
           client,
           apiKey,
-          emulatorHost: emulatorHost,
-          emulatorPort: emulatorPort,
+          emulator: emulator,
         ),
         refreshToken,
         autoRefresh: autoRefresh,

--- a/lib/src/firebase_auth.dart
+++ b/lib/src/firebase_auth.dart
@@ -1,5 +1,6 @@
 import 'package:http/http.dart';
 
+import 'emulator_config.dart';
 import 'firebase_account.dart';
 import 'models/auth_exception.dart';
 import 'models/fetch_provider_request.dart';
@@ -22,11 +23,8 @@ class FirebaseAuth {
   /// The default locale to be used for E-Mails sent by Firebase.
   String? locale;
 
-  /// The URL host of the firebase auth emulator
-  final String? emulatorHost;
-
-  /// The port of the firebase auth emulator
-  final int? emulatorPort;
+  /// options for connect to the firebase auth emulator
+  final EmulatorConfig? emulator;
 
   /// Creates a new firebase auth instance.
   ///
@@ -36,14 +34,12 @@ class FirebaseAuth {
   FirebaseAuth(
     Client client,
     String apiKey, {
-    this.emulatorHost,
-    this.emulatorPort,
     this.locale,
+    this.emulator,
   }) : api = RestApi(
           client,
           apiKey,
-          emulatorHost: emulatorHost,
-          emulatorPort: emulatorPort,
+          emulator: emulator,
         );
 
   /// Creates a new firebase auth instance.
@@ -53,9 +49,8 @@ class FirebaseAuth {
   /// property.
   FirebaseAuth.api(
     this.api, {
-    this.emulatorHost,
-    this.emulatorPort,
     this.locale,
+    this.emulator,
   });
 
   /// Returns a list of all providers that can be used to login.

--- a/lib/src/firebase_auth.dart
+++ b/lib/src/firebase_auth.dart
@@ -22,6 +22,12 @@ class FirebaseAuth {
   /// The default locale to be used for E-Mails sent by Firebase.
   String? locale;
 
+  /// The URL host of the firebase auth emulator
+  final String? emulatorHost;
+
+  /// The port of the firebase auth emulator
+  final int? emulatorPort;
+
   /// Creates a new firebase auth instance.
   ///
   /// The instance uses [client] and [apiKey] for accessing the Firebase REST
@@ -29,9 +35,16 @@ class FirebaseAuth {
   /// the [FirebaseAuth.locale] property.
   FirebaseAuth(
     Client client,
-    String apiKey, [
+    String apiKey, {
+    this.emulatorHost,
+    this.emulatorPort,
     this.locale,
-  ]) : api = RestApi(client, apiKey);
+  }) : api = RestApi(
+          client,
+          apiKey,
+          emulatorHost: emulatorHost,
+          emulatorPort: emulatorPort,
+        );
 
   /// Creates a new firebase auth instance.
   ///
@@ -39,9 +52,11 @@ class FirebaseAuth {
   /// [locale] is specified, it is used to initialize the [FirebaseAuth.locale]
   /// property.
   FirebaseAuth.api(
-    this.api, [
+    this.api, {
+    this.emulatorHost,
+    this.emulatorPort,
     this.locale,
-  ]);
+  });
 
   /// Returns a list of all providers that can be used to login.
   ///

--- a/lib/src/rest_api.dart
+++ b/lib/src/rest_api.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 
 import 'package:http/http.dart';
 
+import 'emulator_config.dart';
 import 'models/auth_exception.dart';
 import 'models/delete_request.dart';
 import 'models/fetch_provider_request.dart';
@@ -36,11 +37,11 @@ class RestApi {
   /// The Firebase Web-API-Key to authenticate to the remote api
   final String apiKey;
 
-  /// The URL host of the firebase auth emulator
-  final String? emulatorHost;
-
-  /// The port of the firebase auth emulator
-  final int? emulatorPort;
+  /// Config to connect to the Firebase auth emulator
+  ///
+  /// When set requests will be sent to the Firebase auth emulator
+  /// instead of the production endpoints
+  final EmulatorConfig? emulator;
 
   /// Create a new api instance
   ///
@@ -49,8 +50,7 @@ class RestApi {
   const RestApi(
     this.client,
     this.apiKey, {
-    required this.emulatorHost,
-    required this.emulatorPort,
+    this.emulator,
   });
 
   /// https://firebase.google.com/docs/reference/rest/auth#section-refresh-token
@@ -260,18 +260,22 @@ class RestApi {
     Map<String, dynamic>? queryParameters,
   }) {
     String host;
-    final productionDomain = isTokenRequest ? _tokenHost : _authHost;
-    if (emulatorHost != null) {
-      host = emulatorHost!;
+    var protocol = 'https';
+    int? port;
+    final targetDomain = isTokenRequest ? _tokenHost : _authHost;
+    if (emulator != null) {
+      host = emulator!.host;
+      protocol = emulator!.protocol;
+      port = emulator!.port;
     } else {
-      host = productionDomain;
+      host = targetDomain;
     }
     return Uri(
-      scheme: emulatorHost != null ? 'http' : 'https',
+      scheme: protocol,
       host: host,
-      port: emulatorPort,
+      port: port,
       pathSegments: [
-        if (emulatorHost != null) productionDomain,
+        if (emulator != null) targetDomain,
         'v1',
         path,
       ],

--- a/lib/src/rest_api.dart
+++ b/lib/src/rest_api.dart
@@ -36,11 +36,22 @@ class RestApi {
   /// The Firebase Web-API-Key to authenticate to the remote api
   final String apiKey;
 
+  /// The URL host of the firebase auth emulator
+  final String? emulatorHost;
+
+  /// The port of the firebase auth emulator
+  final int? emulatorPort;
+
   /// Create a new api instance
   ///
   /// The api is created with [client] and [apiKey] to initialize the
   /// equivalent members. They are used to access the firebase servers.
-  const RestApi(this.client, this.apiKey);
+  const RestApi(
+    this.client,
+    this.apiKey, {
+    required this.emulatorHost,
+    required this.emulatorPort,
+  });
 
   /// https://firebase.google.com/docs/reference/rest/auth#section-refresh-token
   Future<RefreshResponse> token({
@@ -247,19 +258,29 @@ class RestApi {
     String path, {
     bool isTokenRequest = false,
     Map<String, dynamic>? queryParameters,
-  }) =>
-      Uri(
-        scheme: 'https',
-        host: isTokenRequest ? _tokenHost : _authHost,
-        pathSegments: [
-          'v1',
-          path,
-        ],
-        queryParameters: <String, dynamic>{
-          'key': apiKey,
-          ...?queryParameters,
-        },
-      );
+  }) {
+    String host;
+    final productionDomain = isTokenRequest ? _tokenHost : _authHost;
+    if (emulatorHost != null) {
+      host = emulatorHost!;
+    } else {
+      host = productionDomain;
+    }
+    return Uri(
+      scheme: emulatorHost != null ? 'http' : 'https',
+      host: host,
+      port: emulatorPort,
+      pathSegments: [
+        if (emulatorHost != null) productionDomain,
+        'v1',
+        path,
+      ],
+      queryParameters: <String, dynamic>{
+        'key': apiKey,
+        ...?queryParameters,
+      },
+    );
+  }
 
   Future<Map<String, dynamic>> _post(
     Uri url,

--- a/test/integration/account_test.dart
+++ b/test/integration/account_test.dart
@@ -23,16 +23,24 @@ void main() {
 
   setUpAll(() async {
     client = Client();
+    final emulatorHost = await TestConfig.emulatorHost;
+    final emulatorPort = await TestConfig.emulatorPort;
+    EmulatorConfig? emulator;
+    if (emulatorPort != null && emulatorHost != null) {
+      emulator = EmulatorConfig(
+        host: emulatorHost,
+        port: emulatorPort,
+      );
+    }
     auth = FirebaseAuth(
       client,
       await TestConfig.apiKey,
-      emulatorHost: await TestConfig.emulatorHost,
-      emulatorPort: await TestConfig.emulatorPort,
+      emulator: emulator,
     );
-    if (auth.emulatorHost != null && auth.emulatorPort != null) {
+    if (auth.emulator != null) {
       // ignore: avoid_print
       print(
-        'running tests against firebase emulator located at http://${auth.emulatorHost}:${auth.emulatorPort}',
+        'running tests against firebase emulator located at http://${auth.emulator?.host}:${auth.emulator?.port}',
       );
     }
   });

--- a/test/integration/account_test.dart
+++ b/test/integration/account_test.dart
@@ -23,7 +23,18 @@ void main() {
 
   setUpAll(() async {
     client = Client();
-    auth = FirebaseAuth(client, await TestConfig.apiKey);
+    auth = FirebaseAuth(
+      client,
+      await TestConfig.apiKey,
+      emulatorHost: await TestConfig.emulatorHost,
+      emulatorPort: await TestConfig.emulatorPort,
+    );
+    if (auth.emulatorHost != null && auth.emulatorPort != null) {
+      // ignore: avoid_print
+      print(
+        'running tests against firebase emulator located at http://${auth.emulatorHost}:${auth.emulatorPort}',
+      );
+    }
   });
 
   tearDownAll(() {

--- a/test/integration/test_config.dart
+++ b/test/integration/test_config.dart
@@ -5,4 +5,10 @@ abstract class TestConfig {
 
   static Future<String> get apiKey =>
       TestEnv.load().then((c) => c['FIREBASE_API_KEY']!);
+
+  static Future<String?> get emulatorHost =>
+      TestEnv.load().then((c) => c['FIREBASE_EMULATOR_HOST']);
+
+  static Future<int?> get emulatorPort => TestEnv.load()
+      .then((c) => int.tryParse(c['FIREBASE_EMULATOR_PORT'] ?? ''));
 }

--- a/test/unit/firebase_auth_test.dart
+++ b/test/unit/firebase_auth_test.dart
@@ -52,7 +52,7 @@ void main() {
     final auth = FirebaseAuth(
       mockClient,
       apiKey,
-      locale,
+      locale: locale,
     );
 
     expect(auth.api, isNotNull);
@@ -65,7 +65,7 @@ void main() {
     const locale = 'locale';
     final auth = FirebaseAuth.api(
       mockApi,
-      locale,
+      locale: locale,
     );
 
     expect(auth.api, mockApi);
@@ -82,7 +82,7 @@ void main() {
     FirebaseAccount? account;
 
     setUp(() {
-      auth = FirebaseAuth.api(mockApi, 'ab-CD');
+      auth = FirebaseAuth.api(mockApi, locale: 'ab-CD');
     });
 
     tearDown(() async {

--- a/test/unit/rest_api_test.dart
+++ b/test/unit/rest_api_test.dart
@@ -33,7 +33,12 @@ extension FakeResponseX on When<Future<Response>> {
 void main() {
   const apiKey = 'apiKey';
   final mockClient = MockClient();
-  final api = RestApi(mockClient, apiKey);
+  final api = RestApi(
+    mockClient,
+    apiKey,
+    emulatorHost: null,
+    emulatorPort: null,
+  );
 
   When<Future<Response>> whenPost() => when(
         // ignore: discarded_futures

--- a/test/unit/rest_api_test.dart
+++ b/test/unit/rest_api_test.dart
@@ -36,8 +36,6 @@ void main() {
   final api = RestApi(
     mockClient,
     apiKey,
-    emulatorHost: null,
-    emulatorPort: null,
   );
 
   When<Future<Response>> whenPost() => when(


### PR DESCRIPTION
This PR adds an `EmulatorConfig` class that can be passed to the following classes and constructors using the optional `emulator` parameter
- FirebaseAuth
- FirebaseAuth.api
- FirebaseAccount.create
- RestApi

When an `EmulatorConfig` has been passed in, requests will be made to the Firebase auth emulator instead of the production endpoints.

__Example:__
```dart
// connecting to emulator
final api = RestApi(
  http.Client(),
  "<api-key>",
  emulator: EmulatorConfig(
    host: "localhost",
    port: 9050,
  ),
);

// not connecting to emulator
final api = RestApi(
  http.Client(),
  "<api-key>",
);
```

There were a handful of breaking changes which have been outlined below:

## Breaking Changes

- `locale` is no longer a positional parameter in `FirebaseAuth`. It has been changed to a named parameter to make room for the `emulator` parameter.
- `locale` is no longer a positional parameter in `FirebaseAuth.api`. It has been changed to a named parameter to make room for the `emulator` parameter.

## Other Changes

- Tests now check for `FIREBASE_EMULATOR_HOST` and `FIREBASE_EMULATOR_PORT` .env variables to optionally run tests against the Firebase auth emulator.
- Document `.env` values in `.env.example`
- `example/main.dart` can now optionally accept 2nd and 3rd parameters to specify emulator host and emulator port.

Example:
```bash
# run normally
dart run example/main.dart <api-key>

# run connected to auth emulator
dart run example/main.dart <api-key> <emulator-host> <emulator-port>
dart run example/main.dart <api-key> 127.0.0.1 9099
```